### PR TITLE
Fix figure specification typo in Chapter 3

### DIFF
--- a/synmod.tex
+++ b/synmod.tex
@@ -179,7 +179,7 @@ No $\datdesc$ or $\exndesc$ may describe {\tt it}.
 }
 \end{itemize}
 %\clearpage %containing figure 'Grammar: Specifications'
-\begin{figure}[m]
+\begin{figure}[t]
 \vspace{4pt}
 \makeatletter{}
 \tabskip\@centering


### PR DESCRIPTION
Hello,

The current LaTeX source of the Definition does not compile with recent versions of TeX Live (e.g., 2016), since they reject ill-formed figure specifications. This patch fixes the problem and results in layout identical to the print version.